### PR TITLE
Add callback for child process reaping

### DIFF
--- a/test/bin/worker.sh
+++ b/test/bin/worker.sh
@@ -19,14 +19,15 @@ LOGFILE=/dev/null
 
 function start_sleeper() {
   local stype=${1:-"random"}
-  local delay=${2:-"$DEFAULT_DELAY_SECS"}
+  local exitCode=${2:-0}
+  local delay=${3:-"$DEFAULT_DELAY_SECS"}
 
   local sleeptime=$delay
   [ "$stype" = "random" ]  &&  sleeptime=$((RANDOM % $delay))
  
-   nohup sleep ${sleeptime} < /dev/null &> /dev/null &
+   nohup sh -c "sleep ${sleeptime} && exit ${exitCode}" < /dev/null &> /dev/null &
    pid=$!
-   echo "  - Worker: $$ - started $stype bg sleeper, pid=$pid" >> "$LOGFILE"
+   echo "  - Worker: $$ - started $stype bg sleeper, pid=$pid, exitCode=$exitCode" >> "$LOGFILE"
 
 }  #  End of function  start_sleeper.
 
@@ -36,11 +37,14 @@ function run_workers() {
   shift
 
   #  Start 1 fixed and 'n' random sleepers.
-  start_sleeper "fixed" "$@"
+  start_sleeper "fixed" 0 "$@"
 
   for i in $(seq $ntimes); do
-     start_sleeper "random" "$@"
+     start_sleeper "random" 0 "$@"
   done
+
+  start_sleeper "random" 1 "$@"
+  start_sleeper "random" 2 "$@"
 
 }  #  End of function  run_workers.
 

--- a/test/build/image.sh
+++ b/test/build/image.sh
@@ -20,13 +20,18 @@ function _build_image() {
 
   mkdir -p "${BUILD_DIR}"
 
-  cp    "${SRC_DIR}/testpid1.go" "${BUILD_DIR}"
+  pushd "${SRC_DIR}" > /dev/null
+
+  echo "  - building testpid1 ... "
+  go build testpid1.go
+
+  popd
+
+  cp    "${SRC_DIR}/testpid1"    "${BUILD_DIR}"
   cp -r "${SRC_DIR}/bin"         "${BUILD_DIR}"
   cp -r "${fixtures}"/*          "${BUILD_DIR}"
 
   pushd "${BUILD_DIR}" > /dev/null
-  echo "  - building testpid1 ... "
-  go build testpid1.go
   echo "  - building ${image} ... "
   docker build -t "${image}" .
   popd

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,0 +1,7 @@
+module reapertest
+
+go 1.23.1
+
+require github.com/ramr/go-reaper v0.2.1
+
+replace github.com/ramr/go-reaper => ../


### PR DESCRIPTION
Add callback for child process reaping

## How to test
- Use this PR locally (or open this PR with Gitpod via https://gitpod.io/#https://github.com/ramr/go-reaper/pull/25 if you want to have a try)
- Exec commands below in terminal
   ```
   cd test
   make image-test
   ```
- Check the output content (`cat /tmp/reaper_test.log`) includes worker with exitCode 1 and 2 (should be 3 times per thread)

## Why?

Because `Reap()` can be racing with `cmd.Wait()`

<details>

<summary>Example Fake Code</summary>

https://github.com/gitpod-io/gitpod/blob/04faad14a30854c664c61ac15a1c9d27ebeb50ee/components/supervisor/cmd/init.go#L79-L103

```
func fakeCode() {
	done := make(chan struct{})
	go func() {
		defer close(done)

		err := cmd.Wait()
		if err != nil && !(strings.Contains(err.Error(), "signal: ") || strings.Contains(err.Error(), "no child processes")) {
			if eerr, ok := err.(*exec.ExitError); ok && eerr.ExitCode() != 0 {
				logs := extractFailureFromDevTerminationLog()
				if shared.IsExpectedShutdown(eerr.ExitCode()) {
					log.Fatal(logs)
				} else {
					log.WithError(fmt.Errorf(logs)).Fatal("cmd run error with unexpected exit code")
				}
			}
			log.WithError(err).Error("cmd run error")
			return
		}
	}()
	reaper.Reap()

	select {
	case <-done:
		return
	}
}
```
</details>
