### PR TITLE
Wrappers to adapt the "into the woods" pattern

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,9 @@
 # FROM scratch
 FROM fedora
 
-MAINTAINER  smitram@gmail.com
+LABEL org.opencontainers.image.authors="smitram@gmail.com"
+
+RUN yum install -y procps
 
 COPY  ./bin            /reaper/bin
 COPY  testpid1         /reaper/testpid1

--- a/test/Makefile
+++ b/test/Makefile
@@ -27,7 +27,7 @@ clean:
 	$(RM) /tmp/reaper-tests/*.log
 
 test:	tests
-tests:	build test-image test-debug-on test-notify test-non-pid1 test-oop-init
+tests:	build test-image test-options test-non-pid1 test-oop-init
 	@echo "  - All tests passed."
 
 
@@ -75,12 +75,17 @@ image:
 #
 #  Testing targets.
 #
-test-image:
+test-image:	test-default-image test-missing-config
+
+test-default-image:
 	@echo "  - Running reaper image test ..."
 	./runtests.sh $(TEST_IMAGE) ""
 
+test-missing-config:
 	@echo "  - Running reaper image test with missing reaper.json ..."
 	./runtests.sh $(TEST_IMAGE) /reaper/config/missing-404-reaper.json
+
+test-options: test-debug-on test-notify test-run-forked test-swaddled-options
 
 test-debug-on:
 	@echo "  - Running reaper image debug on test ..."
@@ -96,13 +101,35 @@ test-status-close:
 	@echo "  - Running reaper image status close test ..."
 	./runtests.sh $(TEST_IMAGE) /reaper/config/status-close-reaper.json
 
-test-non-pid1:	test-child-sub-reaper
+test-run-forked:
+	@echo "  - Running reaper image RunForked test ..."
+	./runtests.sh $(TEST_IMAGE) /reaper/config/run-forked.json
+
+test-swaddled-options:	test-with-reaper test-with-reaper-not-main test-with-reaper-panic
+
+test-with-reaper:
+	@echo "  - Running reaper image WithReaper test ..."
+	./runtests.sh $(TEST_IMAGE) /reaper/config/with-reaper.json
+
+test-with-reaper-not-main:
+	@echo "  - Running reaper image WithReaper not main caller test ..."
+	./runtests.sh $(TEST_IMAGE) /reaper/config/with-reaper-not-main.json
+
+test-with-reaper-panic:
+	@echo "  - Running reaper image WithReaper and child panic test ..."
+	./runtests.sh $(TEST_IMAGE) /reaper/config/with-reaper-panic.json || :
+
+test-non-pid1:	test-non-pid1-reaper test-non-pid1-child-sub-reaper
+
+test-non-pid1-reaper:
 	@echo "  - Running reaper image non pid1 test ..."
 	./runtests.sh $(TEST_IMAGE) /reaper/config/non-pid1-reaper.json
 
-test-child-sub-reaper:
+test-non-pid1-child-sub-reaper:
 	@echo "  - Running reaper image non pid1 child-sub-reaper test ..."
 	./runtests.sh $(TEST_IMAGE) /reaper/config/child-sub-reaper.json
+
+
 
 #
 #  Custom image tests.
@@ -113,5 +140,9 @@ test-oop-init:
 
 
 .PHONY:	build clean test tests lint vet image
-.PHONY:	test-image test-debug-on test-notify test-status test-status-close
-.PHONY:	test-non-pid1 test-oop-init
+.PHONY:	test-image test-options test-non-pid1 test-oop-init
+.PHONY:	test-default-image test-missing-config
+.PHONY:	test-debug-on test-notify test-run-forked test-with-reaper-options
+.PHONY:	test-status test-status-close
+.PHONY:	test-with-reaper test-with-reaper-not-main test-with-reaper-panic 
+.PHONY:	test-non-pid1-reaper test-non-pid1-child-sub-reaper test-oop-init

--- a/test/bin/script.sh
+++ b/test/bin/script.sh
@@ -15,14 +15,22 @@
 #           worker-args: 3 4 === create 3 workers (which become orphans) per
 #                                thread with a max sleep time of 4 seconds.
 #
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+readonly WORKER="${SCRIPT_DIR}/worker.sh"
+
+#
+#  main():
+#
 NTIMES=${1:-"5"}
 shift
+set -m
 
 echo  "  - pid $$: $0 started with $NTIMES parallel threads ..."
 
 for idx in $(seq "${NTIMES}"); do
-  nohup bash -c "$SCRIPT_DIR/worker.sh $*" < /dev/null &> /dev/null &
-  pid=$!
-  echo "  - Started background worker #${idx} - pid=${pid}"
+    nohup setsid bash -c "${WORKER} $*" < /dev/null &> /dev/null &
+    pid=$!
+    echo "  - Started detached background worker #${idx} - pid=${pid}"
 done

--- a/test/bin/send-child-signal.sh
+++ b/test/bin/send-child-signal.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+#
+#  main():
+#
+zpid=$(pgrep -a testpid1 | awk '{print $1}' | tail -n 1)
+[ -n "${zpid}" ] || zpid=1
+
+sig=${1:-"USR1"}
+echo "  - Sending pid ${zpid} signal SIG${sig} ..."
+kill -s "${sig}" "${zpid}"

--- a/test/bin/worker.sh
+++ b/test/bin/worker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-#  Usage:  <./worker.sh>  <num-workers>  <sleep-time>
+#  Usage:  $0  <num-workers>  <sleep-time>
 #          where:  <num-workers> = number of workers - default 10.
 #                  <sleep-time>  = max sleep time in seconds - default 5.
 #                                  This is used by the workers to randomly

--- a/test/fixtures/config/child-sub-reaper.json
+++ b/test/fixtures/config/child-sub-reaper.json
@@ -1,5 +1,4 @@
 {
-    "Pid": 0,
     "DisablePid1Check": true,
     "EnableChildSubreaper": true,
     "Status": true,

--- a/test/fixtures/config/debug-reaper.json
+++ b/test/fixtures/config/debug-reaper.json
@@ -1,5 +1,5 @@
 {
-	"Pid": 0,
+	"Pid": -1,
 	"Debug": true,
 	"Options": 0
 }

--- a/test/fixtures/config/non-pid1-reaper.json
+++ b/test/fixtures/config/non-pid1-reaper.json
@@ -1,5 +1,5 @@
 {
-	"Pid": 0,
+	"Pid": -1,
 	"DisablePid1Check": true,
 	"Debug": true,
 	"Options": 0

--- a/test/fixtures/config/run-forked.json
+++ b/test/fixtures/config/run-forked.json
@@ -1,0 +1,8 @@
+{
+	"DisablePid1Check": false,
+	"ErrorExit": true,
+	"RunForked": true,
+	"Status": true,
+	"Debug": true,
+	"Options": 0
+}

--- a/test/fixtures/config/status-close-reaper.json
+++ b/test/fixtures/config/status-close-reaper.json
@@ -1,7 +1,7 @@
 {
-	"Pid": 0,
+	"Pid": -1,
 	"Debug": true,
-        "Status": true,
-        "StatusClose": true,
+	"Status": true,
+	"StatusClose": true,
 	"Options": 0
 }

--- a/test/fixtures/config/status-reaper.json
+++ b/test/fixtures/config/status-reaper.json
@@ -1,6 +1,5 @@
 {
-	"Pid": 0,
 	"Debug": true,
-        "Status": true,
+	"Status": true,
 	"Options": 0
 }

--- a/test/fixtures/config/with-reaper-not-main.json
+++ b/test/fixtures/config/with-reaper-not-main.json
@@ -1,0 +1,10 @@
+{
+	"Pid": -1,
+	"DisablePid1Check": false,
+	"ErrorExit": true,
+	"WithReaper": true,
+	"WithReaperOption": "not-via-main",
+	"Status": false,
+	"Debug": true,
+	"Options": 0
+}

--- a/test/fixtures/config/with-reaper-panic.json
+++ b/test/fixtures/config/with-reaper-panic.json
@@ -1,0 +1,10 @@
+{
+	"Pid": -1,
+	"DisablePid1Check": false,
+	"ErrorExit": true,
+	"WithReaper": true,
+	"WithReaperOption": "child-panic",
+	"Status": false,
+	"Debug": true,
+	"Options": 0
+}

--- a/test/fixtures/config/with-reaper.json
+++ b/test/fixtures/config/with-reaper.json
@@ -1,0 +1,8 @@
+{
+	"Pid": -1,
+	"DisablePid1Check": false,
+	"WithReaper": true,
+	"Status": true,
+	"Debug": true,
+	"Options": 0
+}

--- a/test/fixtures/oop-init/Dockerfile
+++ b/test/fixtures/oop-init/Dockerfile
@@ -1,7 +1,9 @@
 # FROM scratch
 FROM fedora
 
-MAINTAINER  smitram@gmail.com
+LABEL org.opencontainers.image.authors="smitram@gmail.com"
+
+RUN yum install -y procps
 
 ADD ./bin     /reaper/bin
 ADD testpid1  /reaper/testpid1

--- a/test/fixtures/oop-init/testpid1.go
+++ b/test/fixtures/oop-init/testpid1.go
@@ -137,6 +137,8 @@ func startWorkers() {
 
 	fmt.Printf("%s: Started worker: %s %s\n", NAME, script, args)
 
+	cmd.Wait()
+
 } /*  End of function  startWorkers.  */
 
 // Load reaper json and make test options.

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -2,9 +2,14 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
 
 readonly MAX_SLEEP_TIME=$((5 + 2))
 readonly IMAGE="reaper/test"
+
+readonly SCENARIO_LOG="/tmp/reaper-tests/test-scenario.log"
+readonly WORKER_LOG="/tmp/reaper-tests/worker.log"
 
 logfile="/tmp/reaper-tests/test.log"
 
@@ -13,9 +18,7 @@ logfile="/tmp/reaper-tests/test.log"
 #  Return list of sleeper processes.
 #
 function _get_sleepers() {
-    #shellcheck disable=SC2009
-    ps --forest -o pid,ppid,time,cmd -g "${pid1}" |  \
-        grep sleep | grep -v grep
+    docker exec "$1" pgrep sleep
 
 }  #  End of function  _get_sleepers.
 
@@ -24,15 +27,18 @@ function _get_sleepers() {
 #  Check for orphaned processes.
 #
 function _check_orphans() {
-    local pid1=$1
+    local elcid=$1
+
+    local cname=""
+    cname=$(echo "${elcid}" | cut -c 1-12)
 
     sleep "${MAX_SLEEP_TIME}"
     local orphans=""
-    orphans=$(_get_sleepers "${pid1}")
+    orphans=$(_get_sleepers "${elcid}")
 
     if [ -n "${orphans}" ]; then
         echo ""
-        echo "FAIL: Got orphan processes attached to pid ${pid1}"
+        echo "FAIL: Got orphan processes attached to reaper in ${cname}"
         echo "============================================================="
         echo "${orphans}"
         echo "============================================================="
@@ -46,25 +52,73 @@ function _check_orphans() {
 
 
 #
+#  Returns 0 if ErrorExit is set in the associated config.
+#
+function _errorExitEnabled() {
+    local config=${1:-""}
+
+    if [ -z "${config}" ]; then
+        return 1
+    fi
+
+    local cfgjson="${SCRIPT_DIR}/fixtures/config/${config}"
+    if [ -f "${cfgjson}" ]; then
+        if grep -Ee '"ErrorExit":\s*true' "${cfgjson}" ; then
+            #  The death of this process is pre-ordained!
+            return 0
+        fi
+    fi
+
+    return 1
+
+}  #  End of function  _errorExitEnabled.
+
+
+#
+#  Save container worker logs.
+#
+function _save_container_worker_logs() {
+    local logdir=""
+    logdir=$(dirname "${WORKER_LOG}")
+
+    mkdir -p "${logdir}"
+
+    local running=""
+    running=$(docker inspect "$1" -f '{{ .State.Running }}')
+    if [ "z${running}" == "ztrue" ]; then
+        (echo ""; echo "";                                          \
+            echo "----------------------------------------------";  \
+            echo "  - Worker logs:";                                \
+            docker exec "$1" cat /tmp/worker.log;                   \
+            echo "----------------------------------------------";  \
+        ) > "${WORKER_LOG}"
+    fi
+
+    return 0
+
+}  #  End of function  _save_container_worker_logs.
+
+
+#
 #  Terminate docker container.
 #
 function _terminate_container() {
     local logdir=""
-    logdir=$(dirname "${logfile}")
+    logdir=$(dirname "${SCENARIO_LOG}")
 
     mkdir -p "${logdir}"
-    docker logs "$1" > "${logfile}"
+    docker logs "$1" > "${SCENARIO_LOG}"
 
-    #  append worker logs to the logfile.
-    (echo ""; echo "";                                          \
-        echo "----------------------------------------------";  \
-        echo "  - Worker logs:";                                \
-        docker exec "$1" cat /tmp/worker.log;                   \
-        echo "----------------------------------------------";  \
-    ) >> "${logfile}"
+    _save_container_worker_logs "$1"
 
-    echo "  - Container logs saved to ${logfile}"
+    if [ -f "${WORKER_LOG}" ]; then
+        #  append worker logs to the SCENARIO_LOG.
+        cat "${WORKER_LOG}" >> "${SCENARIO_LOG}"
+    fi
 
+    echo "  - Container logs saved to ${SCENARIO_LOG}"
+
+    #echo "  - container not terminated - for debugging!"
     echo "  - Terminated container $(docker rm -f "$1")"
 
 }  #  End of function  _terminate_container.
@@ -88,17 +142,17 @@ function _check_status_exit_codes() {
     #  Check that we have expected status lines.
     for code in 1 2 7 13 21 29 30 31 64 65 66 69 70 71 74 76 77 78 127; do
         local pid=""
-        for pid in $(grep -Ee "exitcode=${code}\$" "${logfile}" |  \
+        for pid in $(grep -Ee "exitcode=${code}\$" "${SCENARIO_LOG}" |  \
                          awk -F '=' '{print $2}' |                 \
                          awk -F ',' '{print $1}' | tr '\r\n' ' '); do
             #echo "  - Descendant pid ${pid} exited with code ${code}"
 
             #  On a slower vm (circa 2014), might not always get the status
             #  reported - it could fill up the channel notifications, so ...
-            if grep "status of pid ${pid}" "${logfile}" > /dev/null; then
+            if grep "status of pid ${pid}" "${SCENARIO_LOG}" > /dev/null; then
                 local reported=""
-                reported=$(grep "status of pid ${pid}" "${logfile}" |   \
-                               sed 's/.*status of pid.*exit code //g' |  \
+                reported=$(grep "status of pid ${pid}" "${SCENARIO_LOG}" | \
+                               sed 's/.*status of pid.*exit code //g' |   \
                                tr -d '\r')
                 if [ "${reported}" -ne "${code}" ]; then
                     echo "ERROR: Child pid ${pid} exited with code ${code},"
@@ -115,9 +169,9 @@ function _check_status_exit_codes() {
 
 
 #
-#  Run reaper tests.
+#  Run a reaper test scenario.
 #
-function _run_tests() {
+function _run_test_scenario() {
     local image=${1:-"${IMAGE}"}
     shift
 
@@ -130,29 +184,49 @@ function _run_tests() {
         name="${config%.*}"
     fi
 
-    logfile="/tmp/reaper-tests/${name}.log"
-
-    echo "  - Removing any existing log file ${logfile} ... "
-    rm -f "${logfile}"
+    echo "  - Logging full test logs to ${logfile} ..."
+    echo "  - Removing any existing ${SCENARIO_LOG} ${WORKER_LOG} ... "
+    rm -f "${SCENARIO_LOG}" "${WORKER_LOG}"
 
     echo "  - Starting docker container running image ${image} with"
     echo "    command line arguments: $*"
     local elcid=""
     elcid=$(docker run -dit "${image}" "$@")
 
-    echo "  - Docker container name=${elcid}"
+    local cname=""
+    cname=$(echo "${elcid}" | cut -c 1-12)
+
+    echo "  - Docker container name=${cname}"
     local pid1=""
     pid1=$(docker inspect --format '{{.State.Pid}}' "${elcid}")
 
     sleep 1.42
 
-    echo "  - Docker container pid=${pid1}"
-    echo "  - PID ${pid1} has $(_get_sleepers "${pid1}" | wc -l) sleepers."
-    echo "  - Sleeping for ${MAX_SLEEP_TIME} seconds ..."
-    sleep "${MAX_SLEEP_TIME}"
+    echo "  - Docker container ${cname}, host process pid=${pid1}"
+    echo "  - ${cname} has $(_get_sleepers "${elcid}" | wc -l) sleepers."
 
-    echo "  - Checking for orphans attached to pid1=${pid1} ..."
-    if ! _check_orphans "${pid1}"; then
+    if [ "${pid1}" != "0" ]; then
+        echo "  - Sleeping for ${MAX_SLEEP_TIME} seconds ..."
+        sleep "${MAX_SLEEP_TIME}"
+    fi
+
+    #  Check if we are expecting error exits.
+    local errorExit="no"
+    if _errorExitEnabled "${config}" ; then
+        errorExit="yes"
+
+        if [ "${pid1}" == "0" ] || ! ps -p "${pid1}" > /dev/null ; then
+            #  Already dead, then do the cleanup.
+            _terminate_container "${elcid}"
+
+            echo ""
+            echo "OK: All tests passed - (1/1)"
+            return
+        fi
+    fi
+
+    echo "  - Checking for orphans attached to container ${cname} ..."
+    if ! _check_orphans "${elcid}"; then
         #  Got an error, cleanup and exit with error code.
         _terminate_container "${elcid}"
         echo ""
@@ -161,23 +235,21 @@ function _run_tests() {
     fi
  
 
-    local cname=""
-    cname=$(echo "${elcid}" | cut -c 1-12)
-    echo "  - Sending SIGUSR1 to ${cname} (pid ${pid1}) to start more workers ..."
-    docker kill -s USR1 "${elcid}"
+    echo "  - Running add more workers in ${cname} ..."
+    docker exec "${elcid}" /reaper/bin/send-child-signal.sh USR1
 
-    sleep 1
-    echo "  - PID ${pid1} has $(_get_sleepers "${pid1}" | wc -l) sleepers."
+    sleep 1.42
+    echo "  - ${cname} has $(_get_sleepers "${elcid}" | wc -l) sleepers."
 
     echo "  - Sleeping once again for ${MAX_SLEEP_TIME} seconds ..."
     sleep "${MAX_SLEEP_TIME}"
 
-    echo "  - Running processes under ${pid1}:"
+    echo "  - Running processes in container ${cname}:"
     pstree "${pid1}"
-    ps --forest -o pid,ppid,time,cmd -g "${pid1}" || :
+    docker exec "${elcid}" ps --forest -o pid,ppid,time,cmd -e || :
 
-    echo "  - Checking for orphans attached to pid1=${pid1} ..."
-    if ! _check_orphans "${pid1}"; then
+    echo "  - Checking for orphans attached to container ${cname} ..."
+    if ! _check_orphans "${elcid}"; then
         #  Got an error, cleanup and exit with error code.
         _terminate_container "${elcid}"
         echo ""
@@ -185,9 +257,17 @@ function _run_tests() {
         exit 65
     fi
 
-    echo "  - Running processes under ${pid1}:"
+    echo "  - Running processes in container ${cname}:"
     pstree "${pid1}"
-    ps --forest -o pid,ppid,time,cmd -g "${pid1}" || :
+    docker exec "${elcid}" ps --forest -o pid,ppid,time,cmd -e || :
+
+    if [ "z${errorExit}" == "zyes" ]; then
+        _save_container_worker_logs "${elcid}"
+
+        echo "  - Send child signal SIGTERM"
+        docker exec "${elcid}" /reaper/bin/send-child-signal.sh TERM
+        sleep 1.42
+    fi
 
     #  Do the cleanup.
     _terminate_container "${elcid}"
@@ -197,6 +277,28 @@ function _run_tests() {
 
     echo ""
     echo "OK: All tests passed - (2/2)"
+
+} #  End of function  _run_test_scenario.
+
+
+#
+#  Run reaper tests.
+#
+function _run_tests() {
+    local image=${1:-"${IMAGE}"}
+    local name="test"
+    name=$(echo "${image}" | awk -F '/' '{print $NF}')
+
+    local config=${2:-""}
+    if [ -n "${config}" ]; then
+        config=$(basename "${config}")
+        name="${config%.*}"
+    fi
+
+    logfile="/tmp/reaper-tests/${name}.log"
+
+    _run_test_scenario  "$@"  | tee "${logfile}"
+    cat "${SCENARIO_LOG}" >> "${logfile}"
 
 } #  End of function  _run_tests.
 

--- a/test/testpid1.go
+++ b/test/testpid1.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -27,6 +28,10 @@ type TestOptions struct {
 	Debug                bool
 	Status               bool
 	StatusClose          bool
+	ErrorExit            bool
+	RunForked            bool
+	WithReaper           bool
+	WithReaperOption     string
 }
 
 // Test with a process that sleeps for a short time.
@@ -47,8 +52,8 @@ func sleeperTest(set_proc_attributes bool) {
 		return
 	}
 
-	// Sleep for a wee bit longer to allow the reaper to reap the
-	// command on a slow system.
+	//  Sleep for a wee bit longer to allow the reaper to reap the
+	//  command on a slow system.
 	time.Sleep(4 * time.Second)
 
 	err = cmd.Wait()
@@ -62,6 +67,53 @@ func sleeperTest(set_proc_attributes bool) {
 	}
 
 } /*  End of function  sleeperTest.  */
+
+// Run command with bash -c ...
+func runTestCommand(cmd string, set_proc_attrs bool) {
+	command := exec.Command("bash", "-c", cmd)
+	if set_proc_attrs {
+		command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	}
+
+	fmt.Printf("> bash -c '%v'\n", cmd)
+
+	zout, zerr := command.CombinedOutput()
+	if zerr != nil {
+		os.Stderr.WriteString(zerr.Error())
+	}
+
+	fmt.Println(string(zout))
+
+} /*  End of function  runTestCommand.  */
+
+// Test with a bunch of different commands.
+func runCommandMix() {
+	commands := []string{"ls -a -l -h /tmp", "ls -a -l -h foo.adskdlskldk",
+		"date", "uname -srv", "whoami", "id", "stat /etc/hostname",
+		"cat /etc/hostname", "cat /etc/passwd | wc -c",
+		"cat /etc/passwd | cut -f 1 -d ':' |   sort   | head -n 2",
+	}
+
+	for _, cmd := range commands {
+		runTestCommand(cmd, false)
+		runTestCommand(cmd, true)
+	}
+
+	grepCmd := exec.Command("grep", "hello")
+	grepCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+
+	grepIn, _ := grepCmd.StdinPipe()
+	grepOut, _ := grepCmd.StdoutPipe()
+	grepCmd.Start()
+	grepIn.Write([]byte("hello grepped\ngoodbye\naloha\nciao\nhi\n\n"))
+	grepIn.Close()
+	grepBytes, _ := ioutil.ReadAll(grepOut)
+	grepCmd.Wait()
+
+	fmt.Println("> grep hello")
+	fmt.Println(string(grepBytes))
+
+} /*  End of function  runCommandMix.  */
 
 // Start up test workers that in turn startup child processes, which will
 // get orphaned.
@@ -77,19 +129,63 @@ func startWorkers() {
 	var scriptFile = fmt.Sprintf("%s/bin/script.sh", dir)
 	script, err := filepath.Abs(scriptFile)
 	if err != nil {
-		fmt.Printf("%s: Error getting script - %s\n", NAME, scriptFile)
+		fmt.Printf("%s: Error getting script - %v\n", NAME, scriptFile)
 		return
 	}
 
 	var args = fmt.Sprintf("%d", SCRIPT_THREADS_NUM)
 	var cmd = exec.Command(script, args)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Start()
 
-	fmt.Printf("%s: Started worker: %s %s\n", NAME, script, args)
+	fmt.Printf("%s: Started workers via: %v %v\n", NAME, script, args)
+
+	cmd.Wait()
+
+	fmt.Printf("%v: Script %v completed\n", NAME, script)
 
 } /*  End of function  startWorkers.  */
+
+// Start the test launcher and start an initial set of workers.
+func startLauncher() {
+	fmt.Printf("%v: starting launcher ...\n", NAME)
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGUSR1)
+
+	/*  Run a few test commands.  */
+	runCommandMix()
+
+	/*  Start the initial set of detached workers ... */
+	fmt.Printf("%v: starting detached workers ...\n", NAME)
+	startWorkers()
+
+	for {
+		select {
+		case <-sig:
+			fmt.Printf("%s: Got SIGUSR1, adding detached workers\n", NAME)
+			startWorkers()
+		}
+
+	} /*  End of while doomsday ... */
+
+} /*  End of function  startLauncher.  */
+
+// Start the test processes.
+func startTestProcesses() {
+	time.Sleep(1 * time.Second)
+
+	/*  Run the sleeper test setting the process attributes.  */
+	go sleeperTest(true)
+
+	/*  And run test without setting process attributes.  */
+	go sleeperTest(false)
+
+	startLauncher()
+
+} /*  End of function  startTestProcesses.  */
 
 // Dump exit status of child processes. If flag is set it randomly tests
 // closing the status channel.
@@ -105,7 +201,7 @@ func dumpChildExitStatus(channel chan reaper.Status, flag bool) {
 		select {
 		case status, ok := <-channel:
 			if !ok {
-				// Channel closed, no more work to do.
+				/*  Channel closed, no more work to do.   */
 				fmt.Printf("%v: status channel closed\n", NAME)
 				return
 			}
@@ -139,6 +235,7 @@ func loadTestOptions(config string) *TestOptions {
 		Pid:              -1,
 		Options:          0,
 		DisablePid1Check: false,
+		WithReaperOption: "",
 	}
 
 	decoder := json.NewDecoder(configFile)
@@ -152,16 +249,25 @@ func loadTestOptions(config string) *TestOptions {
 
 } /*  End of function  loadTestOptions.  */
 
-// Start reaper.
-func startReaper(options *TestOptions) {
-	/*  Start the grim reaper ... */
+// Return the test scenario based on the options.
+func getTestScenario(options *TestOptions) string {
 	if options == nil {
-		// No options, test reaper with the default config.
-		fmt.Printf("%s: Using defaults ...\n", NAME)
-		go reaper.Reap()
-		return
+		return "default"
 	}
 
+	if options.RunForked {
+		return "forked"
+	}
+
+	if options.WithReaper {
+		return "swaddled" /*  aka a wrapped child.  */
+	}
+
+	return "options"
+
+} /*  End of function  getTestScenario.  */
+
+func configure(options *TestOptions) reaper.Config {
 	var statusChannel chan reaper.Status
 
 	if options.Status {
@@ -169,48 +275,143 @@ func startReaper(options *TestOptions) {
 		fmt.Printf("%s: status channel enabled, random close=%v\n",
 			NAME, flag)
 
-		// make a buffered channel with max 42 entries.
+		/*  Make a buffered channel with max 42 entries.  */
 		statusChannel = make(chan reaper.Status, 42)
 		go dumpChildExitStatus(statusChannel, flag)
 	}
 
-	config := reaper.Config{
+	return reaper.Config{
 		Pid:                  options.Pid,
 		Options:              options.Options,
 		DisablePid1Check:     options.DisablePid1Check,
 		EnableChildSubreaper: options.EnableChildSubreaper,
 		Debug:                options.Debug,
 		StatusChannel:        statusChannel,
+		CloneEnvIndicator:    "_REAPER_TEST",
+		DisableCallerCheck:   false,
 	}
 
-	go reaper.Start(config)
+} /*  End of function  configure.  */
 
-	/*  Run the sleeper test setting the process attributes.  */
-	go sleeperTest(true)
+// Test default Reap method.
+func testReap() {
+	fmt.Printf("%s: Using defaults ...\n", NAME)
 
-	/*  And run test without setting process attributes.  */
-	go sleeperTest(false)
+	/*  No options, test reaper with the default config.  */
+	go reaper.Reap()
 
-} /*  End of function startReaper.  */
+	startLauncher()
 
-// Launch the test processes.
-func launchTest() {
+} /*  End of function  testReap.  */
+
+// Wait for termination signal (SIGTERM).
+func waitForTerminationSignal() {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGUSR1)
-
-	/*  Start the initial set of workers ... */
-	startWorkers()
+	signal.Notify(sig, syscall.SIGTERM)
 
 	for {
 		select {
 		case <-sig:
-			fmt.Printf("%s: Got SIGUSR1, adding workers ...\n", NAME)
-			startWorkers()
+			fmt.Printf("%s: Got termination signal, exiting ...\n", NAME)
+			return
 		}
 
 	} /*  End of while doomsday ... */
 
-} /*  End of function  launchTest.  */
+} /*  End of function  waitForTerminationSignal.  */
+
+// Test reaper started in forked mode.
+func testRunForked(options *TestOptions) {
+	config := configure(options)
+
+	expectedCode := 0
+	if options.ErrorExit {
+		/*  This test needs the child to exit on receiving SIGTERM.  */
+		/*  So generate a random exit code between 64-78.  */
+		expectedCode = 64 + rand.Intn(15)
+	}
+
+	reaper.RunForked(config)
+
+	/*  This will run only in the child process.  */
+	go startTestProcesses()
+
+	waitForTerminationSignal()
+	fmt.Printf("%s: Exiting with code = %v\n", NAME, expectedCode)
+	os.Exit(expectedCode)
+
+} /*  End of function  testRunForked.  */
+
+// Run reaper started in "swaddled" mode.
+func runWithReaper(options *TestOptions) {
+	expectedCode := 0
+	if options.ErrorExit {
+		/*  This test needs the child to exit on receiving SIGTERM.  */
+		/*  So generate a random exit code between 64-78.  */
+		expectedCode = 64 + rand.Intn(15)
+	}
+
+	config := configure(options)
+
+	reaper.WithReaper(config, func(err error) int {
+		if err != nil {
+			fmt.Printf("%s: WithReaper error = %v\n", NAME, err)
+
+			if options.WithReaperOption == "not-via-main" {
+				fmt.Printf("%s: WithReaper not-via-main check OK\n", NAME)
+				return 0
+			}
+
+			// Huh? Return EX_SOFTWARE, some internal error.
+			fmt.Printf("%s: WithReaper unexpected error\n", NAME)
+			fmt.Printf("%s: WithReaper exit code 70\n", NAME)
+			return 70
+		}
+
+		go startTestProcesses()
+
+		waitForTerminationSignal()
+		if options.WithReaperOption == "child-panic" {
+			fmt.Printf("%s: WithReaper child-panic test!\n", NAME)
+			panic("test WithReaper child panic option")
+		}
+
+		fmt.Printf("%s: WithReaper exit code %v\n", NAME, expectedCode)
+		return expectedCode
+	})
+
+	//  Should never reach here as WithReaper calls exit.
+	msg := "POST WithReaper - should _NEVER_ reach here!"
+	fmt.Printf("%s: %s\n", NAME, msg)
+	panic(msg)
+
+} /*  End of function  runWithReaper.  */
+
+// Test WithReaper process.
+func testWithReaper(options *TestOptions) {
+	if options.WithReaperOption == "not-via-main" {
+		go runWithReaper(options)
+
+		waitForTerminationSignal()
+
+		os.Exit(0) // or we can just return.
+		return
+	}
+
+	runWithReaper(options)
+
+} /*  End of function  testWithReaper.  */
+
+// Test reaper start with config.
+func testStartReaper(options *TestOptions) {
+	/*  Start the grim reaper ... */
+	config := configure(options)
+
+	go reaper.Start(config)
+
+	startTestProcesses()
+
+} /*  End of function testStartReaper.  */
 
 // main test entry point.
 func main() {
@@ -220,8 +421,22 @@ func main() {
 	}
 
 	options := loadTestOptions(config)
-	startReaper(options)
 
-	launchTest()
+	switch getTestScenario(options) {
+	case "default":
+		testReap()
+
+	case "forked":
+		testRunForked(options)
+
+	case "swaddled":
+		testWithReaper(options)
+
+	case "options":
+		testStartReaper(options)
+
+	default:
+		testStartReaper(options)
+	}
 
 } /*  End of function  main.  */


### PR DESCRIPTION
Adapts the "into the woods" to create a `RunForked` call to run the reaper process with a forked child and execute user code in the forked child. This is the nuts and bolts version of it.
And then there's a wrapper around that called `WithReaper` to give you a scoped callback.

fixes #28 